### PR TITLE
Adds RBAC config for Helm

### DIFF
--- a/cluster-components/helm/rbac-config.yml
+++ b/cluster-components/helm/rbac-config.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system


### PR DESCRIPTION
Helm requires a `ClusterRoleBinding` in RBAC-enabled cluster, included in this PR.