### PR TITLE
Configure nginx-ingress SSL handling and DNS

### DIFF
--- a/cluster-components/nginx-ingress/helm-values.yml
+++ b/cluster-components/nginx-ingress/helm-values.yml
@@ -1,0 +1,39 @@
+controller:
+  replicaCount: 3
+
+  # Add a snippet to each nginx server{} block, forcing HTTP->HTTPS
+  # redirection regardless of Ingress rule config
+  config:
+    server-snippet: |
+      if ($http_x_forwarded_proto != 'https') {
+        return 308 https://$host$request_uri;
+      }
+
+  # nginx-ingress's ServiceType=LoadBalancer by default, so we're mainly
+  # configuring an ELB here
+  service:
+    annotations:
+      # Have `external-dns` create a Route53 record pointing to this ELB
+      external-dns.alpha.kubernetes.io/hostname: "*.apps.cloud-platforms-sandbox.k8s.integration.dsd.io"
+
+      # Attach pre-existing ACM cert
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:926803513772:certificate/d737162e-7dc3-434b-ba0c-b0d9fcb53e7c"
+
+      # Enable ELB SSL protocol on port 443 only (default is all ports)
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+
+      # Use HTTP protocol for instance traffic, as we're terminating on the ELB
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+
+    # Direct ELB HTTPS traffic to instance HTTP port, as we're terminating on
+    # the ELB
+    targetPorts:
+      https: 80
+
+    # Preserve source IP address
+    externalTrafficPolicy: "Local"
+
+# Create RBAC role with required perms for nginx-ingress's ServiceAccount
+rbac:
+  create: true
+  serviceAccountName: default

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,21 @@
+resource "aws_acm_certificate" "apps" {
+  domain_name = "*.apps.${local.sandbox_domain_name}"
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "apps_cert_validation" {
+  name = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_type}"
+  zone_id = "${aws_route53_zone.sandbox.id}"
+  records = ["${aws_acm_certificate.apps.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "apps" {
+  certificate_arn = "${aws_acm_certificate.apps.arn}"
+  validation_record_fqdns = ["${aws_route53_record.apps_cert_validation.fqdn}"]
+}
+
+output "apps_acm_arn" {
+  value = "${aws_acm_certificate.apps.arn}"
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -5,10 +5,6 @@ data "aws_route53_zone" "integration" {
 
 
 # parent DNS zone for all clusters
-locals {
-  k8s_domain_name = "${var.k8s_domain_prefix}.${var.base_domain_name}"
-}
-
 resource "aws_route53_zone" "k8s" {
   name = "${local.k8s_domain_name}."
 }
@@ -26,10 +22,6 @@ resource "aws_route53_record" "k8s_ns" {
 
 
 # DNS zone for sandbox cluster
-locals {
-  sandbox_domain_name = "${var.sandbox_domain_prefix}.${local.k8s_domain_name}"
-}
-
 resource "aws_route53_zone" "sandbox" {
   name = "${local.sandbox_domain_name}."
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,6 +7,11 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.1"
+  version = "~> 1.9.0"
   region = "eu-west-1"
+}
+
+locals {
+  k8s_domain_name = "${var.k8s_domain_prefix}.${var.base_domain_name}"
+  sandbox_domain_name = "${var.sandbox_domain_prefix}.${local.k8s_domain_name}"
 }


### PR DESCRIPTION
We want to use nginx-ingress to handle all inbound traffic, with SSL termination at its ELB, forcing HTTP->HTTPS redirection, preserving source IP address, and with a wildcard DNS entry (*.apps.cluster) pointing to the ELB. This PR:
    
- adds an ACM certificate with Terraform for attachment to the ELB, using DNS request validation 
- adds a HTTP->HTTPS redirect to all applications' nginx server{} directive
- adds a DNS record annotation for the Service ELB, for use by external-dns
- adds an annotation containing an ACM ARN (cert must already exist and match the DNS name specified for external-dns)
- configure the ELB to handle SSL traffic on port 443 only
- configure the ELB to use non-SSL HTTP for instance traffic (so SSL is terminated on the ELB)
- configure the ELB to also send non-HTTP traffic to nginx-ingress, so it can be redirected to HTTPS/443
- configure the ELB to preserve the clients' source IP address
- creates a service account for nginx-ingress, as the cluster has RBAC enabled