### PR TITLE
Adds Helm values file for external-dns

### DIFF
--- a/cluster-components/external-dns/helm-values.yml
+++ b/cluster-components/external-dns/helm-values.yml
@@ -1,0 +1,30 @@
+## This controls which types of resource external-dns should 'watch' for new
+## DNS entries.
+sources:
+  - service
+
+## The DNS provider where the DNS records will be created (options: aws, google, inmemory, azure )
+provider: aws
+
+# AWS Access keys to inject as environment variables
+aws:
+  region: "eu-west-1"
+  # Filter for zones of this type (optional, options: public, private)
+  zoneType: "public"
+
+## Limit possible target zones by domain suffixes (optional)
+domainFilters:
+  - cloud-platforms-sandbox.k8s.integration.dsd.io
+
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: true
+  # Beginning with Kubernetes 1.8, the api is stable and v1 can be used.
+  apiVersion: v1
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default
+
+logLevel: debug


### PR DESCRIPTION
Configures external-dns to manage records in the cloud-platforms-sandbox.k8s.integration.dsd.io DNS zone only, and only for Service objects as we’ll be using a single shared ELB with a wildcard DNS record for now.