### PR TITLE
Configure Danger to review pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+script:
+  - gem install ministryofjustice-danger --version '~> 0.1' && danger

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,1 @@
+danger.import_dangerfile(github: 'ministryofjustice/danger')


### PR DESCRIPTION
We should use [our existing Danger configuration](https://github.com/ministryofjustice/danger) to make sure our pull requests and commits are in line with the MOJ's standards (as much as we can, anyway).