### PR TITLE
Refactor Terraform resources

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -1,0 +1,48 @@
+# Setup
+terraform {
+  backend "s3" {
+    bucket = "moj-cp-k8s-investigation-platform-terraform"
+    region = "eu-west-1"
+    key = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.9.0"
+  region = "eu-west-1"
+}
+
+data "terraform_remote_state" "global" {
+    backend = "s3"
+    config {
+        bucket = "moj-cp-k8s-investigation-global-terraform"
+        region = "eu-west-1"
+        key = "terraform.tfstate"
+    }
+}
+
+locals {
+    cluster_name = "${terraform.workspace}"
+    cluster_base_domain_name = "${local.cluster_name}.k8s.integration.dsd.io"
+}
+
+# Modules
+module "cluster_dns" {
+    source = "../modules/cluster_dns"
+
+    cluster_base_domain_name = "${local.cluster_base_domain_name}"
+    parent_zone_id = "${data.terraform_remote_state.global.k8s_zone_id}"
+}
+
+module "cluster_ssl" {
+    source = "../modules/cluster_ssl"
+
+    cluster_base_domain_name = "${local.cluster_base_domain_name}"
+    dns_zone_id = "${module.cluster_dns.cluster_dns_zone_id}"
+}
+
+module "kops_state" {
+    source = "../modules/kops_state"
+
+    cluster_name = "${local.cluster_name}"
+}

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {
+    default = "eu-west-1"
+}

--- a/terraform/global-resources/dns.tf
+++ b/terraform/global-resources/dns.tf
@@ -1,0 +1,20 @@
+# Reference to existing base DNS zone
+data "aws_route53_zone" "base" {
+  name = "${var.base_domain_name}."
+}
+
+# parent DNS zone for all clusters
+resource "aws_route53_zone" "k8s" {
+  name = "${var.k8s_domain_prefix}.${var.base_domain_name}."
+}
+
+resource "aws_route53_record" "k8s_ns" {
+  zone_id = "${data.aws_route53_zone.base.zone_id}"
+  name    = "${var.k8s_domain_prefix}.${var.base_domain_name}"
+  type    = "NS"
+  ttl     = "30"
+
+  records = [
+    "${aws_route53_zone.k8s.name_servers}"
+  ]
+}

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {
+    bucket = "moj-cp-k8s-investigation-global-terraform"
+    region = "eu-west-1"
+    key = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.9.0"
+  region = "eu-west-1"
+}

--- a/terraform/global-resources/outputs.tf
+++ b/terraform/global-resources/outputs.tf
@@ -1,0 +1,7 @@
+output "k8s_zone_id" {
+    value = "${aws_route53_zone.k8s.zone_id}"
+}
+
+output "k8s_domain_name" {
+    value = "${var.k8s_domain_prefix}.${var.base_domain_name}"
+}

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "platform_terraform" {
+  bucket = "moj-cp-k8s-investigation-platform-terraform"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+}

--- a/terraform/global-resources/variables.tf
+++ b/terraform/global-resources/variables.tf
@@ -1,0 +1,7 @@
+variable "base_domain_name" {
+  default = "integration.dsd.io"
+}
+
+variable "k8s_domain_prefix" {
+  default = "k8s"
+}

--- a/terraform/modules/cluster_dns/dns.tf
+++ b/terraform/modules/cluster_dns/dns.tf
@@ -1,0 +1,14 @@
+resource "aws_route53_zone" "cluster" {
+  name = "${var.cluster_base_domain_name}."
+}
+
+resource "aws_route53_record" "parent_zone_cluster_ns" {
+  zone_id = "${var.parent_zone_id}"
+  name    = "${aws_route53_zone.cluster.name}"
+  type    = "NS"
+  ttl     = "30"
+
+  records = [
+    "${aws_route53_zone.cluster.name_servers}"
+  ]
+}

--- a/terraform/modules/cluster_dns/outputs.tf
+++ b/terraform/modules/cluster_dns/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_dns_zone_name" {
+    value = "${aws_route53_zone.cluster.name}"
+}
+
+output "cluster_dns_zone_id" {
+    value = "${aws_route53_zone.cluster.zone_id}"
+}

--- a/terraform/modules/cluster_dns/variables.tf
+++ b/terraform/modules/cluster_dns/variables.tf
@@ -1,0 +1,2 @@
+variable "cluster_base_domain_name" {}
+variable "parent_zone_id" {}

--- a/terraform/modules/cluster_ssl/acm.tf
+++ b/terraform/modules/cluster_ssl/acm.tf
@@ -1,0 +1,17 @@
+resource "aws_acm_certificate" "apps" {
+  domain_name       = "*.apps.${var.cluster_base_domain_name}"
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "apps_cert_validation" {
+  name    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_type}"
+  zone_id = "${var.dns_zone_id}"
+  records = ["${aws_acm_certificate.apps.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "apps" {
+  certificate_arn         = "${aws_acm_certificate.apps.arn}"
+  validation_record_fqdns = ["${aws_route53_record.apps_cert_validation.fqdn}"]
+}

--- a/terraform/modules/cluster_ssl/outputs.tf
+++ b/terraform/modules/cluster_ssl/outputs.tf
@@ -1,0 +1,3 @@
+output "apps_acm_arn" {
+  value = "${aws_acm_certificate.apps.arn}"
+}

--- a/terraform/modules/cluster_ssl/variables.tf
+++ b/terraform/modules/cluster_ssl/variables.tf
@@ -1,0 +1,2 @@
+variable "cluster_base_domain_name" {}
+variable "dns_zone_id" {}

--- a/terraform/modules/kops_state/s3.tf
+++ b/terraform/modules/kops_state/s3.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "kops_state_store" {
+  bucket = "moj-cp-kops-${var.cluster_name}"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+}

--- a/terraform/modules/kops_state/variables.tf
+++ b/terraform/modules/kops_state/variables.tf
@@ -1,0 +1,1 @@
+variable "cluster_name" {}


### PR DESCRIPTION
As we're about to start adding more Terraform resources, a more structured approach is required to allow us to separate out per-environment resources from shared "global" resources, and to allow us to apply platform/cluster-level resources repeatedly in multiple environments (e.g. production, staging, individual dev environments, etc.)

This PR:
- moves top-level Terraform resources to [Terraform modules](https://www.terraform.io/docs/modules/usage.html) 
- makes use of [Terraform workspaces](https://www.terraform.io/docs/state/workspaces.html), to allow us to apply the same resources to multiple environments
- splits Terraform state into "global" for resources that aren't environment specific (parent DNS, platform environment state S3 bucket), and "platform" for environment-specific resources

*Note* - Terraform resources have been copied into `cloud-platform` and `global-resources` rather than being refactored in place, so as to not interfere with existing state, and due to workspace not being in current use this has not been tested. To apply these changes, [terraform state will need to be manipulated](https://www.terraform.io/docs/commands/state/mv.html).