### PR TITLE
Move aws_federation TF module to global resources

### DIFF
--- a/rules/add-github-teams-to-saml-mappings.js
+++ b/rules/add-github-teams-to-saml-mappings.js
@@ -24,7 +24,7 @@ function (user, context, callback) {
 
       // IAM resource constants
       // `idp_arn` - reference to the SAML provider that has a trust relationship with AWS
-      var idp_arn = "arn:aws:iam::926803513772:saml-provider/cloud-platforms-sandbox-auth0";
+      var idp_arn = "arn:aws:iam::926803513772:saml-provider/shared-auth0";
       var role_base_arn = "arn:aws:iam::926803513772:role/";
 
       // Add list of IAM roles that the user can assume, one role per Github team

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -40,13 +40,3 @@ module "cluster_ssl" {
     cluster_base_domain_name = "${local.cluster_base_domain_name}"
     dns_zone_id = "${module.cluster_dns.cluster_dns_zone_id}"
 }
-
-module "aws_federation" {
-    source = "../modules/aws_federation"
-
-    env = "${terraform.workspace}"
-    saml_x509_cert = "${var.aws_federation_saml_x509_cert}"
-    saml_idp_domain = "${var.aws_federation_saml_idp_domain}"
-    saml_login_url = "${var.aws_federation_saml_login_url}"
-    saml_logout_url = "${var.aws_federation_saml_logout_url}"
-}

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -10,3 +10,13 @@ provider "aws" {
   version = "~> 1.9.0"
   region = "eu-west-1"
 }
+
+module "aws_federation" {
+    source = "../modules/aws_federation"
+
+    env = "shared"
+    saml_x509_cert = "${var.aws_federation_saml_x509_cert}"
+    saml_idp_domain = "${var.aws_federation_saml_idp_domain}"
+    saml_login_url = "${var.aws_federation_saml_login_url}"
+    saml_logout_url = "${var.aws_federation_saml_logout_url}"
+}


### PR DESCRIPTION
As the aws_federation Terraform module creates a temporary webops admin IAM role with a fixed name it currently causes an error when attempting to apply Terraform resources in multiple workspaces, as IAM role names are unique.

In the long term IAM roles should be created dynamically, either via Github events or as part of the identity broker authentication flow. For now though, the simplest thing to do is to move the federation module into the `global-resources` TF resources, as they are not workspace-specific.

As this modifies both `global-resources` and `cloud-platform` state, `terraform apply` will need to be run in the `global-resources` context, and each `cloud-platform` workspace.