### PR TITLE
added ecr creds creation in global resources

### DIFF
--- a/terraform/global-resources/ecr_credentials.tf
+++ b/terraform/global-resources/ecr_credentials.tf
@@ -1,0 +1,7 @@
+# ECR credentials and Repository creation                                                                                                    
+module "webops_ecr_credentials" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=master"
+
+  repo_name = "cloud-platform-reference-app"
+  team_name = "webops"
+}


### PR DESCRIPTION
this pr is related to bullet point 
An ecr_credentials.tf file has been added to global-resources in kubernetes-investigations which imports and uses the module to create a user, policy and credentials

of issue:
https://github.com/ministryofjustice/cloud-platform-reference-app/issues/29

the ecr_credentials.tf file create the user , ecr repo and credentilas for the demo app