### PR TITLE
Add test-0 cluster

### DIFF
--- a/kops/cloud-platform-test-0.yaml
+++ b/kops/cloud-platform-test-0.yaml
@@ -1,0 +1,120 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: null
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  additionalPolicies:
+    node: |
+      [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "route53:ChangeResourceRecordSets"
+          ],
+          "Resource": [
+            "arn:aws:route53:::hostedzone/"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "route53:ListHostedZones",
+            "route53:ListResourceRecordSets"
+          ],
+          "Resource": [
+            "*"
+          ]
+        }
+      ]
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubeAPIServer:
+    oidcClientID: v4RZTVG2LW16hUf04phmKnRSGqSlTVNh
+    oidcIssuerURL: https://moj-cloud-platforms-dev.eu.auth0.com/
+    oidcUsernameClaim: nickname
+    oidcGroupsClaim: https://k8s.integration.dsd.io/groups
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: 1.10.3
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: master-eu-west-1a
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: master-eu-west-1b
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: master-eu-west-1c
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: nodes
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.medium
+  maxSize: 3
+  minSize: 3
+  role: Node
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  name: bastions
+spec:
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: t2.micro
+  maxSize: 1
+  minSize: 1
+  role: Bastion


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/164

I need a separate test cluster to do concourse work on without stepping
on Mitch's toes. When I commissioned the `test-1` cluster, I **should**
have named it `test-0`. This fills that gap in the sequence.

TODO: Remove the `cloud-platforms-test` cluster.