### PR TITLE
kops audit logs 

### DIFF
--- a/kops/cloud-platform-test-1.yaml
+++ b/kops/cloud-platform-test-1.yaml
@@ -6,187 +6,162 @@ spec:
   fileAssets:
   - name: kubernetes-audit
     path: /srv/kubernetes/audit.yaml
-    # which type of instances to appy the file
     roles: [Master]
     content: |
-      ---
+      # The following audit policy is based on two sources from upstream:
+      #   - the kubernetes docs example: https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/audit/audit-policy.yaml
+      #   - the GCE reference policy: https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh#L784
+      #
       apiVersion: audit.k8s.io/v1beta1
       kind: Policy
+      omitStages:
+        - "RequestReceived"
       rules:
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
         - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
           resources:
-            - group: ""
-              resources:
-                - endpoints
-                - services
-                - services/status
+            - group: "" # core
+              resources: ["endpoints", "services", "services/status"]
+        - level: None
+          namespaces: ["ingress-controllers"]
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["configmaps"]
+              resourceNames: ["ingress-controller-leader-nginx"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["nodes", "nodes/status"]
+        - level: None
           users:
-            - 'system:kube-proxy'
-          verbs:
-            - watch
-
-        - level: None
+            - system:kube-controller-manager
+            - system:kube-scheduler
+            - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
           resources:
-            - group: ""
-              resources:
-                - nodes
-                - nodes/status
-          userGroups:
-            - 'system:nodes'
-          verbs:
-            - get
-
+            - group: "" # core
+              resources: ["endpoints"]
         - level: None
-          namespaces:
-            - kube-system
+          users: ["system:apiserver"]
+          verbs: ["get"]
           resources:
-            - group: ""
-              resources:
-                - endpoints
+            - group: "" # core
+              resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
           users:
-            - 'system:kube-controller-manager'
-            - 'system:kube-scheduler'
-            - 'system:serviceaccount:kube-system:endpoint-controller'
-          verbs:
-            - get
-            - update
-
-        - level: None
+            - system:kube-controller-manager
+          verbs: ["get", "list"]
           resources:
-            - group: ""
-              resources:
-                - namespaces
-                - namespaces/status
-                - namespaces/finalize
-          users:
-            - 'system:apiserver'
-          verbs:
-            - get
-
-        - level: None
-          resources:
-            - group: metrics.k8s.io
-          users:
-            - 'system:kube-controller-manager'
-          verbs:
-            - get
-            - list
-
+            - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
         - level: None
           nonResourceURLs:
-            - '/healthz*'
+            - /healthz*
             - /version
-            - '/swagger*'
-
+            - /swagger*
+        # Don't log authenticated requests to certain non-resource URL paths.
+        - level: None
+          userGroups: ["system:authenticated"]
+          nonResourceURLs:
+          - "/api*"
+        # Don't log events requests.
         - level: None
           resources:
-            - group: ""
-              resources:
-                - events
+            - group: "" # core
+              resources: ["events"]
 
-        - level: Request
-          omitStages:
-            - RequestReceived
-          resources:
-            - group: ""
-              resources:
-                - nodes/status
-                - pods/status
-          users:
-            - kubelet
-            - 'system:node-problem-detector'
-            - 'system:serviceaccount:kube-system:node-problem-detector'
-          verbs:
-            - update
-            - patch
-
-        - level: Request
-          omitStages:
-            - RequestReceived
-          resources:
-            - group: ""
-              resources:
-                - nodes/status
-                - pods/status
-          userGroups:
-            - 'system:nodes'
-          verbs:
-            - update
-            - patch
-
-        - level: Request
-          omitStages:
-            - RequestReceived
-          users:
-            - 'system:serviceaccount:kube-system:namespace-controller'
-          verbs:
-            - deletecollection
-
+        # Log "pods/log", "pods/status" at Metadata level
         - level: Metadata
-          omitStages:
-            - RequestReceived
           resources:
-            - group: ""
-              resources:
-                - secrets
-                - configmaps
-            - group: authentication.k8s.io
-              resources:
-                - tokenreviews
-
+          - group: ""
+            resources: ["pods/log", "pods/status"]
+        # node and pod status calls from nodes are high-volume and can be large, don't log responses for expected updates from nodes
         - level: Request
-          omitStages:
-            - RequestReceived
+          users: ["kubelet", "system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"]
+          verbs: ["update","patch"]
           resources:
-            - group: ""
-            - group: admissionregistration.k8s.io
-            - group: apiextensions.k8s.io
-            - group: apiregistration.k8s.io
-            - group: apps
+            - group: "" # core
+              resources: ["nodes/status", "pods/status"]
+        - level: Request
+          userGroups: ["system:nodes"]
+          verbs: ["update","patch"]
+          resources:
+            - group: "" # core
+              resources: ["nodes/status", "pods/status"]
+        # deletecollection calls can be large, don't log responses for expected namespace deletions
+        - level: Request
+          users: ["system:serviceaccount:kube-system:namespace-controller"]
+          verbs: ["deletecollection"]
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+            - group: "" # core
+              resources: ["secrets", "configmaps"]
             - group: authentication.k8s.io
-            - group: authorization.k8s.io
-            - group: autoscaling
-            - group: batch
-            - group: certificates.k8s.io
-            - group: extensions
-            - group: metrics.k8s.io
-            - group: networking.k8s.io
-            - group: policy
-            - group: rbac.authorization.k8s.io
-            - group: scheduling.k8s.io
-            - group: settings.k8s.io
-            - group: storage.k8s.io
-          verbs:
-            - get
-            - list
-            - watch
-
+              resources: ["tokenreviews"]
+        # Get repsonses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources:
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+        # Default level for known APIs
         - level: RequestResponse
-          omitStages:
-            - RequestReceived
           resources:
-            - group: ""
-            - group: admissionregistration.k8s.io
-            - group: apiextensions.k8s.io
-            - group: apiregistration.k8s.io
-            - group: apps
-            - group: authentication.k8s.io
-            - group: authorization.k8s.io
-            - group: autoscaling
-            - group: batch
-            - group: certificates.k8s.io
-            - group: extensions
-            - group: metrics.k8s.io
-            - group: networking.k8s.io
-            - group: policy
-            - group: rbac.authorization.k8s.io
-            - group: scheduling.k8s.io
-            - group: settings.k8s.io
-            - group: storage.k8s.io
-
+          - group: "" # core
+          - group: "admissionregistration.k8s.io"
+          - group: "apiextensions.k8s.io"
+          - group: "apiregistration.k8s.io"
+          - group: "apps"
+          - group: "authentication.k8s.io"
+          - group: "authorization.k8s.io"
+          - group: "autoscaling"
+          - group: "batch"
+          - group: "certificates.k8s.io"
+          - group: "extensions"
+          - group: "metrics.k8s.io"
+          - group: "networking.k8s.io"
+          - group: "policy"
+          - group: "rbac.authorization.k8s.io"
+          - group: "scheduling.k8s.io"
+          - group: "settings.k8s.io"
+          - group: "storage.k8s.io"
+        # Default level for all other requests.
         - level: Metadata
           omitStages:
-            - RequestReceived
+            - "RequestReceived"
+
   api:
     loadBalancer:
       type: Public

--- a/kops/cloud-platform-test-1.yaml
+++ b/kops/cloud-platform-test-1.yaml
@@ -3,6 +3,190 @@ kind: Cluster
 metadata:
   creationTimestamp: null
 spec:
+  fileAssets:
+  - name: kubernetes-audit
+    path: /srv/kubernetes/audit.yaml
+    # which type of instances to appy the file
+    roles: [Master]
+    content: |
+      ---
+      apiVersion: audit.k8s.io/v1beta1
+      kind: Policy
+      rules:
+        - level: None
+          resources:
+            - group: ""
+              resources:
+                - endpoints
+                - services
+                - services/status
+          users:
+            - 'system:kube-proxy'
+          verbs:
+            - watch
+
+        - level: None
+          resources:
+            - group: ""
+              resources:
+                - nodes
+                - nodes/status
+          userGroups:
+            - 'system:nodes'
+          verbs:
+            - get
+
+        - level: None
+          namespaces:
+            - kube-system
+          resources:
+            - group: ""
+              resources:
+                - endpoints
+          users:
+            - 'system:kube-controller-manager'
+            - 'system:kube-scheduler'
+            - 'system:serviceaccount:kube-system:endpoint-controller'
+          verbs:
+            - get
+            - update
+
+        - level: None
+          resources:
+            - group: ""
+              resources:
+                - namespaces
+                - namespaces/status
+                - namespaces/finalize
+          users:
+            - 'system:apiserver'
+          verbs:
+            - get
+
+        - level: None
+          resources:
+            - group: metrics.k8s.io
+          users:
+            - 'system:kube-controller-manager'
+          verbs:
+            - get
+            - list
+
+        - level: None
+          nonResourceURLs:
+            - '/healthz*'
+            - /version
+            - '/swagger*'
+
+        - level: None
+          resources:
+            - group: ""
+              resources:
+                - events
+
+        - level: Request
+          omitStages:
+            - RequestReceived
+          resources:
+            - group: ""
+              resources:
+                - nodes/status
+                - pods/status
+          users:
+            - kubelet
+            - 'system:node-problem-detector'
+            - 'system:serviceaccount:kube-system:node-problem-detector'
+          verbs:
+            - update
+            - patch
+
+        - level: Request
+          omitStages:
+            - RequestReceived
+          resources:
+            - group: ""
+              resources:
+                - nodes/status
+                - pods/status
+          userGroups:
+            - 'system:nodes'
+          verbs:
+            - update
+            - patch
+
+        - level: Request
+          omitStages:
+            - RequestReceived
+          users:
+            - 'system:serviceaccount:kube-system:namespace-controller'
+          verbs:
+            - deletecollection
+
+        - level: Metadata
+          omitStages:
+            - RequestReceived
+          resources:
+            - group: ""
+              resources:
+                - secrets
+                - configmaps
+            - group: authentication.k8s.io
+              resources:
+                - tokenreviews
+
+        - level: Request
+          omitStages:
+            - RequestReceived
+          resources:
+            - group: ""
+            - group: admissionregistration.k8s.io
+            - group: apiextensions.k8s.io
+            - group: apiregistration.k8s.io
+            - group: apps
+            - group: authentication.k8s.io
+            - group: authorization.k8s.io
+            - group: autoscaling
+            - group: batch
+            - group: certificates.k8s.io
+            - group: extensions
+            - group: metrics.k8s.io
+            - group: networking.k8s.io
+            - group: policy
+            - group: rbac.authorization.k8s.io
+            - group: scheduling.k8s.io
+            - group: settings.k8s.io
+            - group: storage.k8s.io
+          verbs:
+            - get
+            - list
+            - watch
+
+        - level: RequestResponse
+          omitStages:
+            - RequestReceived
+          resources:
+            - group: ""
+            - group: admissionregistration.k8s.io
+            - group: apiextensions.k8s.io
+            - group: apiregistration.k8s.io
+            - group: apps
+            - group: authentication.k8s.io
+            - group: authorization.k8s.io
+            - group: autoscaling
+            - group: batch
+            - group: certificates.k8s.io
+            - group: extensions
+            - group: metrics.k8s.io
+            - group: networking.k8s.io
+            - group: policy
+            - group: rbac.authorization.k8s.io
+            - group: scheduling.k8s.io
+            - group: settings.k8s.io
+            - group: storage.k8s.io
+
+        - level: Metadata
+          omitStages:
+            - RequestReceived
   api:
     loadBalancer:
       type: Public
@@ -41,8 +225,11 @@ spec:
     oidcIssuerURL: https://moj-cloud-platforms-dev.eu.auth0.com/
     oidcUsernameClaim: nickname
     oidcGroupsClaim: https://k8s.integration.dsd.io/groups
-    runtimeConfig:
-      audit.k8s.io/v1beta1: "true"
+    auditLogPath: /var/log/kube-apiserver-audit.log
+    auditLogMaxAge: 10
+    auditLogMaxBackups: 1
+    auditLogMaxSize: 100
+    auditPolicyFile: /srv/kubernetes/audit.yaml
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.11.2


### PR DESCRIPTION
Amended Kops clusterspec to include audit-logging. Defining where logs are stored / size. 

Added fileAssets to include audit policy - defining what events should be included.