### PR TITLE
Switch over Kuberos image and secure connection

### DIFF
--- a/cluster-components/kuberos/cloud-platform-live-0/kuberos.yml
+++ b/cluster-components/kuberos/cloud-platform-live-0/kuberos.yml
@@ -43,7 +43,7 @@ metadata:
   name: kuberos
 spec:
   ports:
-  - port: 80
+  - port: 443
     name: http
     targetPort: http
   selector:
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: kuberos
-        image: negz/kuberos:14f4ca7
+        image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform/kuberos:1888d946522dd4770accd3f47ba4023b1d0b0f88
         command:
         - "/kuberos"
         - "$(OIDC_ISSUER_URL)"


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#121

**WHAT**
- Change kuberos port to 443 instead of 80
- Update deployment image to point to the new kuberos

**WHY**
Switching over the image, deploys the new kuberos to `cloud-platform-live-0`. 