### PR TITLE
Increase live-0 node count

### DIFF
--- a/kops/cloud-platform-live-0.yaml
+++ b/kops/cloud-platform-live-0.yaml
@@ -266,6 +266,6 @@ metadata:
 spec:
   image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
   machineType: c4.2xlarge
-  maxSize: 3
-  minSize: 3
+  maxSize: 6
+  minSize: 6
   role: Node


### PR DESCRIPTION
Due to the nature of EBS volumes being tied to a single AZ in AWS, when performing a rolling-update in nodes there is a period between terminating a node and when the replacement is launched during which, pods using EBS volumes are unable to schedule.

This change doubles the number of nodes so that there is always at least one available per zone during a rolling update.