### PR TITLE
Add admission controller in kops manifest

### DIFF
--- a/kops/cloud-platform-live-0.yaml
+++ b/kops/cloud-platform-live-0.yaml
@@ -205,6 +205,19 @@ spec:
     auditLogMaxBackups: 1
     auditLogMaxSize: 100
     auditPolicyFile: /srv/kubernetes/audit.yaml
+    enableAdmissionPlugins:
+    - Initializers
+    - NamespaceLifecycle
+    - LimitRanger
+    - ServiceAccount
+    - PersistentVolumeLabel
+    - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
+    - NodeRestriction
+    - ResourceQuota
+    - PodSecurityPolicy
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.10.3

--- a/kops/cloud-platform-test-1.yaml
+++ b/kops/cloud-platform-test-1.yaml
@@ -205,6 +205,19 @@ spec:
     auditLogMaxBackups: 1
     auditLogMaxSize: 100
     auditPolicyFile: /srv/kubernetes/audit.yaml
+    enableAdmissionPlugins:
+    - Initializers
+    - NamespaceLifecycle
+    - LimitRanger
+    - ServiceAccount
+    - PersistentVolumeLabel
+    - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - MutatingAdmissionWebhook
+    - ValidatingAdmissionWebhook
+    - NodeRestriction
+    - ResourceQuota
+    - PodSecurityPolicy
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.11.2


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/203

**WHAT**
- This PR contains enables the Admission Controller on both the test-1 and live-0 clusters. Merging this PR does not automatically amend both clusters as a manual `kops update` is required. This has already been performed on test-1. 

**WHY**
- The Admission Controllers allow me to enabled the PodSecurityPolicies as required in https://github.com/ministryofjustice/cloud-platform/issues/203. 

**NOTES**
- It was advised to enable other admission controllers in this PR. 
- If you'd like to know more about Admission Controllers, please see [here](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)