### PR TITLE
Add generate request id to ingress-controllers

### DIFF
--- a/cluster-components/nginx-ingress/cloud-platform-live-0-helm-values.yaml
+++ b/cluster-components/nginx-ingress/cloud-platform-live-0-helm-values.yaml
@@ -4,6 +4,7 @@ controller:
   # Add a snippet to each nginx server{} block, forcing HTTP->HTTPS
   # redirection regardless of Ingress rule config
   config:
+    generate-request-id: "true"
     # Increase proxy_buffer_size from the default of 4k
     proxy-buffer-size: "16k"
 

--- a/cluster-components/nginx-ingress/cloud-platform-test-1-helm-values.yaml
+++ b/cluster-components/nginx-ingress/cloud-platform-test-1-helm-values.yaml
@@ -16,7 +16,6 @@ controller:
         return 308 https://$host$request_uri;
       }
     
-  
   stats:
     enabled: true
 

--- a/cluster-components/nginx-ingress/cloud-platform-test-1-helm-values.yaml
+++ b/cluster-components/nginx-ingress/cloud-platform-test-1-helm-values.yaml
@@ -4,6 +4,7 @@ controller:
   # Add a snippet to each nginx server{} block, forcing HTTP->HTTPS
   # redirection regardless of Ingress rule config
   config: 
+    generate-request-id: "true"
     # Increase proxy_buffer_size from the default of 4k
     proxy-buffer-size: "16k"
 
@@ -14,7 +15,8 @@ controller:
       if ($http_x_forwarded_proto != 'https') {
         return 308 https://$host$request_uri;
       }
-
+    
+  
   stats:
     enabled: true
 


### PR DESCRIPTION
WHAT
HTTP requests reaching a service to include an X-Request-Id header.

WHY
Able to send back a unique request ID with every response; useful for debugging projects but also for offering support to any third parties who might use the service