### PR TITLE
Change the worker nodes size in Kops

### DIFF
--- a/kops/cloud-platform-live-0.yaml
+++ b/kops/cloud-platform-live-0.yaml
@@ -265,7 +265,7 @@ metadata:
   name: nodes
 spec:
   image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
-  machineType: c4.2xlarge
+  machineType: c4.xlarge
   maxSize: 6
   minSize: 6
   role: Node


### PR DESCRIPTION
After some investigation, it was discovered that we aren't utilising the full capacity of the cluster. We've decided that we can cut the instance size in half and scale horizontally if required.