### PR TITLE
Automate metrics-server install

### DIFF
--- a/terraform/cloud-platform-components/metris-server.tf
+++ b/terraform/cloud-platform-components/metris-server.tf
@@ -1,0 +1,30 @@
+resource "helm_release" "metrics_server" {
+  name      = "metrics-server"
+  chart     = "stable/metrics-server"
+  namespace = "kube-system"
+  keyring   = ""
+  version   = "2.0.4"
+  
+  values = [<<EOF
+rbac:
+  create: true
+
+serviceaccount:
+  create: true
+
+apiservice:
+  create: true
+
+image:
+  repository: gcr.io/google_containers/metrics-server-amd64
+  tag: v0.3.1
+  pullpolicy: IfNotPresent
+
+args:
+  value[0]: "--kubelet-insecure-tls"
+  value[1]: "--logtostderr"
+
+EOF
+  ]
+
+}

--- a/terraform/cloud-platform-components/metris-server.tf
+++ b/terraform/cloud-platform-components/metris-server.tf
@@ -5,7 +5,6 @@ resource "helm_release" "metrics_server" {
   keyring   = ""
   version   = "2.0.4"
 
-  
   set {
     name  = "args[0]"
     value = "--kubelet-insecure-tls"

--- a/terraform/cloud-platform-components/metris-server.tf
+++ b/terraform/cloud-platform-components/metris-server.tf
@@ -4,7 +4,7 @@ resource "helm_release" "metrics_server" {
   namespace = "kube-system"
   keyring   = ""
   version   = "2.0.4"
-  
+
   values = [<<EOF
 rbac:
   create: true
@@ -26,5 +26,4 @@ args:
 
 EOF
   ]
-
 }

--- a/terraform/cloud-platform-components/metris-server.tf
+++ b/terraform/cloud-platform-components/metris-server.tf
@@ -5,25 +5,14 @@ resource "helm_release" "metrics_server" {
   keyring   = ""
   version   = "2.0.4"
 
-  values = [<<EOF
-rbac:
-  create: true
+  
+  set {
+    name  = "args[0]"
+    value = "--kubelet-insecure-tls"
+  }
 
-serviceaccount:
-  create: true
-
-apiservice:
-  create: true
-
-image:
-  repository: gcr.io/google_containers/metrics-server-amd64
-  tag: v0.3.1
-  pullpolicy: IfNotPresent
-
-args:
-  value[0]: "--kubelet-insecure-tls"
-  value[1]: "--logtostderr"
-
-EOF
-  ]
+  set {
+    name  = "args[1]"
+    value = "--logtostderr"
+  }
 }


### PR DESCRIPTION
WHAT

Use terraform to automate installation of metrics server on k8s clusters

WHY

Able to run kubectl top nodes/pods on cluster 